### PR TITLE
fixes line graphs with prediction enabled for chrome v > 48

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.js
+++ b/src/js/Rickshaw.Graph.Renderer.js
@@ -110,7 +110,7 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 			i++;
 
 			// support for a line breakpoint
-			if (series.lineBreakPoint && (series.data.length > series.lineBreakPoint) && !series.noPrediction) {
+			if (series.lineBreakPoint && series.path.pathSegList && (series.data.length > series.lineBreakPoint) && !series.noPrediction) {
 
 				var pathStash = [];
 				for (var j = series.path.pathSegList.numberOfItems; j > series.lineBreakPoint; j--) {


### PR DESCRIPTION
@ztanner This is your pull request, but on the correct repository. +1 btw. Good catch.

What Zack Tanner wrote on the other PR:

In Chrome 48+, line graphs that had future data resulted in ugliness as follows:
https://monosnap.com/file/rml18zrbM5I3hYu18FKLXCAcZ4IOJE

This is because SVGPathSeg is deprecated and will be removed in Chrome 48. See https://www.chromestatus.com/feature/5708851034718208. As a result, series.path.pathSegList is undefined.

A new interface will be available, namely getPathData (https://svgwg.org/specs/paths/#InterfaceSVGPathData), but in the meantime, this will prevent the above screenshot. It seems the only side effect is no dashed line.
